### PR TITLE
Partial song requirement

### DIFF
--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -51,7 +51,7 @@ class BottleNumber
       BottleNumber6
     else
       BottleNumber
-    end.new(number)
+    end.new(number, max: 99)
   end
 
   attr_reader :number, :max

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -41,7 +41,7 @@ end
 
 
 class BottleNumber
-  def self.for(number, max: 99)
+  def self.for(number, max:)
     case number
     when 0
       BottleNumber0
@@ -81,7 +81,7 @@ class BottleNumber
   end
 
   def successor
-    BottleNumber.for(number - 1)
+    BottleNumber.for(number - 1, max: max)
   end
 end
 
@@ -95,7 +95,7 @@ class BottleNumber0 < BottleNumber
   end
 
   def successor
-    BottleNumber.for(max)
+    BottleNumber.for(max, max: max)
   end
 end
 

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -55,7 +55,7 @@ class BottleNumber
   end
 
   attr_reader :number, :max
-  def initialize(number, max: 99)
+  def initialize(number, max:)
     @number = number
     @max = max
   end

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -26,6 +26,10 @@ class BottleVerse
       99
     end
 
+    def min
+      0
+    end
+
     def lyrics(number, max: self.max)
       new(BottleNumber.for(number, max: max)).lyrics
     end

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -21,8 +21,14 @@ end
 
 
 class BottleVerse
-  def self.lyrics(number, max: 99)
-    new(BottleNumber.for(number, max: max)).lyrics
+  class << self
+    def max
+      99
+    end
+
+    def lyrics(number, max: self.max)
+      new(BottleNumber.for(number, max: max)).lyrics
+    end
   end
 
   attr_reader :bottle_number

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -1,7 +1,7 @@
 class CountdownSong
   attr_reader :verse_template, :max, :min
 
-  def initialize(verse_template:, max: verse_template.max, min: 0)
+  def initialize(verse_template:, max: verse_template.max, min: verse_template.min)
     @verse_template = verse_template
     @max, @min = max, min
   end

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -41,7 +41,7 @@ end
 
 
 class BottleNumber
-  def self.for(number)
+  def self.for(number, max: 99)
     case number
     when 0
       BottleNumber0
@@ -51,7 +51,7 @@ class BottleNumber
       BottleNumber6
     else
       BottleNumber
-    end.new(number, max: 99)
+    end.new(number, max: max)
   end
 
   attr_reader :number, :max

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -95,7 +95,7 @@ class BottleNumber0 < BottleNumber
   end
 
   def successor
-    BottleNumber.for(99)
+    BottleNumber.for(max)
   end
 end
 

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -54,9 +54,10 @@ class BottleNumber
     end.new(number)
   end
 
-  attr_reader :number
-  def initialize(number)
+  attr_reader :number, :max
+  def initialize(number, max: 99)
     @number = number
+    @max = max
   end
 
   def to_s

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -21,8 +21,8 @@ end
 
 
 class BottleVerse
-  def self.lyrics(number)
-    new(BottleNumber.for(number)).lyrics
+  def self.lyrics(number, max: 99)
+    new(BottleNumber.for(number, max: max)).lyrics
   end
 
   attr_reader :bottle_number

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -1,7 +1,7 @@
 class CountdownSong
   attr_reader :verse_template, :max, :min
 
-  def initialize(verse_template:, max: 999999, min: 0)
+  def initialize(verse_template:, max: verse_template.max, min: 0)
     @verse_template = verse_template
     @max, @min = max, min
   end

--- a/lib/bottles.rb
+++ b/lib/bottles.rb
@@ -15,7 +15,7 @@ class CountdownSong
   end
 
   def verse(number)
-    verse_template.lyrics(number)
+    verse_template.lyrics(number, max: max)
   end
 end
 

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -10,7 +10,7 @@ module VerseRoleTest
 end
 
 class VerseFake
-  def self.lyrics(number)
+  def self.lyrics(number, max: nil)
     "This is verse #{number}.\n"
   end
 end

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -139,6 +139,44 @@ class CountdownSongTest < Minitest::Test
 end
 
 class Bottles99IntegrationTest < Minitest::Test
+  def test_partial_7_bottles_song
+    skip
+    expected = <<-SONG
+7 bottles of beer on the wall, 7 bottles of beer.
+Take one down and pass it around, 1 six-pack of beer on the wall.
+
+1 six-pack of beer on the wall, 1 six-pack of beer.
+Take one down and pass it around, 5 bottles of beer on the wall.
+
+5 bottles of beer on the wall, 5 bottles of beer.
+Take one down and pass it around, 4 bottles of beer on the wall.
+
+4 bottles of beer on the wall, 4 bottles of beer.
+Take one down and pass it around, 3 bottles of beer on the wall.
+
+3 bottles of beer on the wall, 3 bottles of beer.
+Take one down and pass it around, 2 bottles of beer on the wall.
+
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+
+1 bottle of beer on the wall, 1 bottle of beer.
+Take it down and pass it around, no more bottles of beer on the wall.
+
+No more bottles of beer on the wall, no more bottles of beer.
+Go to the store and buy some more, 7 bottles of beer on the wall.
+    SONG
+
+    assert_equal(
+      expected,
+      CountdownSong.new(
+        verse_template: BottleVerse,
+        max: 7,
+        min: 0
+      ).song
+    )
+  end
+
   def test_99_bottles_song
     expected = <<-SONG
 99 bottles of beer on the wall, 99 bottles of beer.

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -139,7 +139,7 @@ class CountdownSongTest < Minitest::Test
         .verses(99, 97))
   end
 
-  def test_song
+  def test_song_with_explicit_max_min_values
     expected =
       "This is verse 47.\n" +
       "\n" +
@@ -155,6 +155,27 @@ class CountdownSongTest < Minitest::Test
       CountdownSong.new(verse_template: VerseFake,
                         max: 47,
                         min: 43)
+        .song)
+  end
+
+  def test_song
+    expected =
+      "This is verse 11.\n" +
+      "\n" +
+      "This is verse 10.\n" +
+      "\n" +
+      "This is verse 9.\n" +
+      "\n" +
+      "This is verse 8.\n" +
+      "\n" +
+      "This is verse 7.\n" +
+      "\n" +
+      "This is verse 6.\n" +
+      "\n" +
+      "This is verse 5.\n"
+    assert_equal(
+      expected,
+      CountdownSong.new(verse_template: VerseFake)
         .song)
   end
 end
@@ -502,10 +523,7 @@ Go to the store and buy some more, 99 bottles of beer on the wall.
 
     assert_equal(
       expected,
-      CountdownSong.new(
-        verse_template: BottleVerse,
-        min: 0
-      ).song
+      CountdownSong.new(verse_template: BottleVerse).song
     )
   end
 end

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -6,12 +6,19 @@ require_relative '../lib/bottles'
 module VerseRoleTest
   def test_plays_verse_role
     assert_respond_to @role_player, :lyrics
+    assert_respond_to @role_player, :max
   end
 end
 
 class VerseFake
-  def self.lyrics(number, max: nil)
-    "This is verse #{number}.\n"
+  class << self
+    def max
+      11
+    end
+
+    def lyrics(number, max: nil)
+      "This is verse #{number}.\n"
+    end
   end
 end
 

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -93,6 +93,15 @@ class BottleVerseTest < Minitest::Test
       "99 bottles of beer on the wall.\n"
     assert_equal expected, BottleVerse.lyrics(0)
   end
+
+  def test_verse_0_with_explicit_max_value
+    expected =
+      "No more bottles of beer on the wall, " +
+      "no more bottles of beer.\n" +
+      "Go to the store and buy some more, " +
+      "7 bottles of beer on the wall.\n"
+    assert_equal expected, BottleVerse.lyrics(0, max: 7)
+  end
 end
 
 

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -149,7 +149,6 @@ end
 
 class Bottles99IntegrationTest < Minitest::Test
   def test_partial_7_bottles_song
-    skip
     expected = <<-SONG
 7 bottles of beer on the wall, 7 bottles of beer.
 Take one down and pass it around, 1 six-pack of beer on the wall.

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -7,6 +7,7 @@ module VerseRoleTest
   def test_plays_verse_role
     assert_respond_to @role_player, :lyrics
     assert_respond_to @role_player, :max
+    assert_respond_to @role_player, :min
   end
 end
 
@@ -14,6 +15,10 @@ class VerseFake
   class << self
     def max
       11
+    end
+
+    def min
+      5
     end
 
     def lyrics(number, max: nil)

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -499,7 +499,6 @@ Go to the store and buy some more, 99 bottles of beer on the wall.
       expected,
       CountdownSong.new(
         verse_template: BottleVerse,
-        max: 99,
         min: 0
       ).song
     )

--- a/test/bottles_test.rb
+++ b/test/bottles_test.rb
@@ -137,3 +137,318 @@ class CountdownSongTest < Minitest::Test
         .song)
   end
 end
+
+class Bottles99IntegrationTest < Minitest::Test
+  def test_99_bottles_song
+    expected = <<-SONG
+99 bottles of beer on the wall, 99 bottles of beer.
+Take one down and pass it around, 98 bottles of beer on the wall.
+
+98 bottles of beer on the wall, 98 bottles of beer.
+Take one down and pass it around, 97 bottles of beer on the wall.
+
+97 bottles of beer on the wall, 97 bottles of beer.
+Take one down and pass it around, 96 bottles of beer on the wall.
+
+96 bottles of beer on the wall, 96 bottles of beer.
+Take one down and pass it around, 95 bottles of beer on the wall.
+
+95 bottles of beer on the wall, 95 bottles of beer.
+Take one down and pass it around, 94 bottles of beer on the wall.
+
+94 bottles of beer on the wall, 94 bottles of beer.
+Take one down and pass it around, 93 bottles of beer on the wall.
+
+93 bottles of beer on the wall, 93 bottles of beer.
+Take one down and pass it around, 92 bottles of beer on the wall.
+
+92 bottles of beer on the wall, 92 bottles of beer.
+Take one down and pass it around, 91 bottles of beer on the wall.
+
+91 bottles of beer on the wall, 91 bottles of beer.
+Take one down and pass it around, 90 bottles of beer on the wall.
+
+90 bottles of beer on the wall, 90 bottles of beer.
+Take one down and pass it around, 89 bottles of beer on the wall.
+
+89 bottles of beer on the wall, 89 bottles of beer.
+Take one down and pass it around, 88 bottles of beer on the wall.
+
+88 bottles of beer on the wall, 88 bottles of beer.
+Take one down and pass it around, 87 bottles of beer on the wall.
+
+87 bottles of beer on the wall, 87 bottles of beer.
+Take one down and pass it around, 86 bottles of beer on the wall.
+
+86 bottles of beer on the wall, 86 bottles of beer.
+Take one down and pass it around, 85 bottles of beer on the wall.
+
+85 bottles of beer on the wall, 85 bottles of beer.
+Take one down and pass it around, 84 bottles of beer on the wall.
+
+84 bottles of beer on the wall, 84 bottles of beer.
+Take one down and pass it around, 83 bottles of beer on the wall.
+
+83 bottles of beer on the wall, 83 bottles of beer.
+Take one down and pass it around, 82 bottles of beer on the wall.
+
+82 bottles of beer on the wall, 82 bottles of beer.
+Take one down and pass it around, 81 bottles of beer on the wall.
+
+81 bottles of beer on the wall, 81 bottles of beer.
+Take one down and pass it around, 80 bottles of beer on the wall.
+
+80 bottles of beer on the wall, 80 bottles of beer.
+Take one down and pass it around, 79 bottles of beer on the wall.
+
+79 bottles of beer on the wall, 79 bottles of beer.
+Take one down and pass it around, 78 bottles of beer on the wall.
+
+78 bottles of beer on the wall, 78 bottles of beer.
+Take one down and pass it around, 77 bottles of beer on the wall.
+
+77 bottles of beer on the wall, 77 bottles of beer.
+Take one down and pass it around, 76 bottles of beer on the wall.
+
+76 bottles of beer on the wall, 76 bottles of beer.
+Take one down and pass it around, 75 bottles of beer on the wall.
+
+75 bottles of beer on the wall, 75 bottles of beer.
+Take one down and pass it around, 74 bottles of beer on the wall.
+
+74 bottles of beer on the wall, 74 bottles of beer.
+Take one down and pass it around, 73 bottles of beer on the wall.
+
+73 bottles of beer on the wall, 73 bottles of beer.
+Take one down and pass it around, 72 bottles of beer on the wall.
+
+72 bottles of beer on the wall, 72 bottles of beer.
+Take one down and pass it around, 71 bottles of beer on the wall.
+
+71 bottles of beer on the wall, 71 bottles of beer.
+Take one down and pass it around, 70 bottles of beer on the wall.
+
+70 bottles of beer on the wall, 70 bottles of beer.
+Take one down and pass it around, 69 bottles of beer on the wall.
+
+69 bottles of beer on the wall, 69 bottles of beer.
+Take one down and pass it around, 68 bottles of beer on the wall.
+
+68 bottles of beer on the wall, 68 bottles of beer.
+Take one down and pass it around, 67 bottles of beer on the wall.
+
+67 bottles of beer on the wall, 67 bottles of beer.
+Take one down and pass it around, 66 bottles of beer on the wall.
+
+66 bottles of beer on the wall, 66 bottles of beer.
+Take one down and pass it around, 65 bottles of beer on the wall.
+
+65 bottles of beer on the wall, 65 bottles of beer.
+Take one down and pass it around, 64 bottles of beer on the wall.
+
+64 bottles of beer on the wall, 64 bottles of beer.
+Take one down and pass it around, 63 bottles of beer on the wall.
+
+63 bottles of beer on the wall, 63 bottles of beer.
+Take one down and pass it around, 62 bottles of beer on the wall.
+
+62 bottles of beer on the wall, 62 bottles of beer.
+Take one down and pass it around, 61 bottles of beer on the wall.
+
+61 bottles of beer on the wall, 61 bottles of beer.
+Take one down and pass it around, 60 bottles of beer on the wall.
+
+60 bottles of beer on the wall, 60 bottles of beer.
+Take one down and pass it around, 59 bottles of beer on the wall.
+
+59 bottles of beer on the wall, 59 bottles of beer.
+Take one down and pass it around, 58 bottles of beer on the wall.
+
+58 bottles of beer on the wall, 58 bottles of beer.
+Take one down and pass it around, 57 bottles of beer on the wall.
+
+57 bottles of beer on the wall, 57 bottles of beer.
+Take one down and pass it around, 56 bottles of beer on the wall.
+
+56 bottles of beer on the wall, 56 bottles of beer.
+Take one down and pass it around, 55 bottles of beer on the wall.
+
+55 bottles of beer on the wall, 55 bottles of beer.
+Take one down and pass it around, 54 bottles of beer on the wall.
+
+54 bottles of beer on the wall, 54 bottles of beer.
+Take one down and pass it around, 53 bottles of beer on the wall.
+
+53 bottles of beer on the wall, 53 bottles of beer.
+Take one down and pass it around, 52 bottles of beer on the wall.
+
+52 bottles of beer on the wall, 52 bottles of beer.
+Take one down and pass it around, 51 bottles of beer on the wall.
+
+51 bottles of beer on the wall, 51 bottles of beer.
+Take one down and pass it around, 50 bottles of beer on the wall.
+
+50 bottles of beer on the wall, 50 bottles of beer.
+Take one down and pass it around, 49 bottles of beer on the wall.
+
+49 bottles of beer on the wall, 49 bottles of beer.
+Take one down and pass it around, 48 bottles of beer on the wall.
+
+48 bottles of beer on the wall, 48 bottles of beer.
+Take one down and pass it around, 47 bottles of beer on the wall.
+
+47 bottles of beer on the wall, 47 bottles of beer.
+Take one down and pass it around, 46 bottles of beer on the wall.
+
+46 bottles of beer on the wall, 46 bottles of beer.
+Take one down and pass it around, 45 bottles of beer on the wall.
+
+45 bottles of beer on the wall, 45 bottles of beer.
+Take one down and pass it around, 44 bottles of beer on the wall.
+
+44 bottles of beer on the wall, 44 bottles of beer.
+Take one down and pass it around, 43 bottles of beer on the wall.
+
+43 bottles of beer on the wall, 43 bottles of beer.
+Take one down and pass it around, 42 bottles of beer on the wall.
+
+42 bottles of beer on the wall, 42 bottles of beer.
+Take one down and pass it around, 41 bottles of beer on the wall.
+
+41 bottles of beer on the wall, 41 bottles of beer.
+Take one down and pass it around, 40 bottles of beer on the wall.
+
+40 bottles of beer on the wall, 40 bottles of beer.
+Take one down and pass it around, 39 bottles of beer on the wall.
+
+39 bottles of beer on the wall, 39 bottles of beer.
+Take one down and pass it around, 38 bottles of beer on the wall.
+
+38 bottles of beer on the wall, 38 bottles of beer.
+Take one down and pass it around, 37 bottles of beer on the wall.
+
+37 bottles of beer on the wall, 37 bottles of beer.
+Take one down and pass it around, 36 bottles of beer on the wall.
+
+36 bottles of beer on the wall, 36 bottles of beer.
+Take one down and pass it around, 35 bottles of beer on the wall.
+
+35 bottles of beer on the wall, 35 bottles of beer.
+Take one down and pass it around, 34 bottles of beer on the wall.
+
+34 bottles of beer on the wall, 34 bottles of beer.
+Take one down and pass it around, 33 bottles of beer on the wall.
+
+33 bottles of beer on the wall, 33 bottles of beer.
+Take one down and pass it around, 32 bottles of beer on the wall.
+
+32 bottles of beer on the wall, 32 bottles of beer.
+Take one down and pass it around, 31 bottles of beer on the wall.
+
+31 bottles of beer on the wall, 31 bottles of beer.
+Take one down and pass it around, 30 bottles of beer on the wall.
+
+30 bottles of beer on the wall, 30 bottles of beer.
+Take one down and pass it around, 29 bottles of beer on the wall.
+
+29 bottles of beer on the wall, 29 bottles of beer.
+Take one down and pass it around, 28 bottles of beer on the wall.
+
+28 bottles of beer on the wall, 28 bottles of beer.
+Take one down and pass it around, 27 bottles of beer on the wall.
+
+27 bottles of beer on the wall, 27 bottles of beer.
+Take one down and pass it around, 26 bottles of beer on the wall.
+
+26 bottles of beer on the wall, 26 bottles of beer.
+Take one down and pass it around, 25 bottles of beer on the wall.
+
+25 bottles of beer on the wall, 25 bottles of beer.
+Take one down and pass it around, 24 bottles of beer on the wall.
+
+24 bottles of beer on the wall, 24 bottles of beer.
+Take one down and pass it around, 23 bottles of beer on the wall.
+
+23 bottles of beer on the wall, 23 bottles of beer.
+Take one down and pass it around, 22 bottles of beer on the wall.
+
+22 bottles of beer on the wall, 22 bottles of beer.
+Take one down and pass it around, 21 bottles of beer on the wall.
+
+21 bottles of beer on the wall, 21 bottles of beer.
+Take one down and pass it around, 20 bottles of beer on the wall.
+
+20 bottles of beer on the wall, 20 bottles of beer.
+Take one down and pass it around, 19 bottles of beer on the wall.
+
+19 bottles of beer on the wall, 19 bottles of beer.
+Take one down and pass it around, 18 bottles of beer on the wall.
+
+18 bottles of beer on the wall, 18 bottles of beer.
+Take one down and pass it around, 17 bottles of beer on the wall.
+
+17 bottles of beer on the wall, 17 bottles of beer.
+Take one down and pass it around, 16 bottles of beer on the wall.
+
+16 bottles of beer on the wall, 16 bottles of beer.
+Take one down and pass it around, 15 bottles of beer on the wall.
+
+15 bottles of beer on the wall, 15 bottles of beer.
+Take one down and pass it around, 14 bottles of beer on the wall.
+
+14 bottles of beer on the wall, 14 bottles of beer.
+Take one down and pass it around, 13 bottles of beer on the wall.
+
+13 bottles of beer on the wall, 13 bottles of beer.
+Take one down and pass it around, 12 bottles of beer on the wall.
+
+12 bottles of beer on the wall, 12 bottles of beer.
+Take one down and pass it around, 11 bottles of beer on the wall.
+
+11 bottles of beer on the wall, 11 bottles of beer.
+Take one down and pass it around, 10 bottles of beer on the wall.
+
+10 bottles of beer on the wall, 10 bottles of beer.
+Take one down and pass it around, 9 bottles of beer on the wall.
+
+9 bottles of beer on the wall, 9 bottles of beer.
+Take one down and pass it around, 8 bottles of beer on the wall.
+
+8 bottles of beer on the wall, 8 bottles of beer.
+Take one down and pass it around, 7 bottles of beer on the wall.
+
+7 bottles of beer on the wall, 7 bottles of beer.
+Take one down and pass it around, 1 six-pack of beer on the wall.
+
+1 six-pack of beer on the wall, 1 six-pack of beer.
+Take one down and pass it around, 5 bottles of beer on the wall.
+
+5 bottles of beer on the wall, 5 bottles of beer.
+Take one down and pass it around, 4 bottles of beer on the wall.
+
+4 bottles of beer on the wall, 4 bottles of beer.
+Take one down and pass it around, 3 bottles of beer on the wall.
+
+3 bottles of beer on the wall, 3 bottles of beer.
+Take one down and pass it around, 2 bottles of beer on the wall.
+
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+
+1 bottle of beer on the wall, 1 bottle of beer.
+Take it down and pass it around, no more bottles of beer on the wall.
+
+No more bottles of beer on the wall, no more bottles of beer.
+Go to the store and buy some more, 99 bottles of beer on the wall.
+    SONG
+
+    assert_equal(
+      expected,
+      CountdownSong.new(
+        verse_template: BottleVerse,
+        max: 99,
+        min: 0
+      ).song
+    )
+  end
+end


### PR DESCRIPTION
Introduce the requirement that when `CountdownSong` specifies a `max` parameter, the final `BottleVerse` should display the `max` value in its final line, not the magic number `99`.

For example, the last verse of this song:
```ruby
CountdownSong.new(
  verse_template: BottleVerse,
  max: 7,
  min: 0
).song
```

Should be:
```
No more bottles of beer on the wall, no more bottles of beer.
Go to the store and buy some more, 7 bottles of beer on the wall.
```

The commits in this PR introduce an integration test with the new requirement, and then make the incremental changes necessary to [make the test pass](https://github.com/sandimetz/99bottles_ruby/commit/e7db7a2f831577aa42d4ac7050c111d8e92e5950), according to the principles described in [99 Bottles of OOP](https://sandimetz.com/99bottles) by Sandi Metz.

However, the magic number 99 only moved from `BottleNumber0` to `BottleVerse.lyrics`. I thought that this would be a good opportunity to do some further refactoring to:
- Update `BottleVerse` and other verse classes to be responsible for own their defaults for `max` and `min`
- Make both `CountdownSong` and `BottleNumber` use these defaults when explicit values are not provided.

Note: I was tempted to add the `min:` parameter to `BottleVerse.lyrics` and so on, but I kept to the discipline of only making the changes and refactorings necessary to meet the new requirement. If another requirement comes along that alters the lyrics related to the lower limit of the 99 Bottles song, then it might be the right time to introduce the `min:` parameter.